### PR TITLE
fix: Set security-events write perm to upload SARIF

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -139,6 +139,9 @@ jobs:
         run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }}
 
   test-sol:
+    permissions:
+      security-events: write
+
     env:
       ETHERSCAN_API_KEY: ''
 


### PR DESCRIPTION
This is required because workflows have read permissions in this repository for the contents and packages scopes only.
https://github.com/Ortege-xyz/ortege-monorepo/settings/actions
