### PR TITLE
Revert "Revert "Add ortege chain configuration""

### DIFF
--- a/rust/config/z_ortege_testnet_config.json
+++ b/rust/config/z_ortege_testnet_config.json
@@ -1,0 +1,32 @@
+{
+  "chains": {
+    "coston2": {
+      "name": "coston2",
+      "domain": 114,
+      "addresses": {
+        "mailbox": "0x9D23142611F57253AE93bb80173a451C63a3Ef6D",
+        "interchainGasPaymaster": "0xB84fa0d6dD46a5f133AFe7f0E7D13103D2E6584a",
+        "validatorAnnounce": "0x8D63Cb66EdD76eE95a908A2351e4CB93Cb67F705"
+      },
+      "protocol": "ethereum",
+      "finalityBlocks": 1,
+      "index": {
+        "from": 5496919
+      }
+    },
+    "fuji": {
+      "name": "fuji",
+      "domain": 43113,
+      "addresses": {
+        "mailbox": "0xAfa5b6E6feaa2ADcf9A0F8a219C225932Ebee099",
+        "interchainGasPaymaster": "0x2fA9aD16e282947AdB015B78B616EE04076A4Fa5",
+        "validatorAnnounce": "0xb365dA946C99ec40e86Ec4E4c82A7D50EbA8Ca9E"
+      },
+      "protocol": "ethereum",
+      "finalityBlocks": 3,
+      "index": {
+        "from": 24846531
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reverts Ortege-xyz/ortege-monorepo#21

community didn't fix env var for case params and just fixed for cli args.
We need to keep this approach(keep chain config as json file inside the image) still.